### PR TITLE
New Blob Encoding, Re: Proto's Specs on Encoding Blobs More Efficiently

### DIFF
--- a/op-service/eth/blob_test.go
+++ b/op-service/eth/blob_test.go
@@ -54,12 +54,12 @@ func TestInvalidBlobDecoding(t *testing.T) {
 	if err := b.FromData(data); err != nil {
 		t.Fatalf("failed to encode bytes: %v", err)
 	}
-	b[32] = 0x80 // field elements should never have their highest order bit set
+	b[1] = 0x01 // wrong version of encoding
 	if _, err := b.ToData(); err == nil {
 		t.Errorf("expected error, got none")
 	}
 
-	b[32] = 0x00
+	b[0] = 0x00
 	b[4] = 0xFF // encode an invalid (much too long) length prefix
 	if _, err := b.ToData(); err == nil {
 		t.Errorf("expected error, got none")


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This is an implementation of Proto's [specs] (https://github.com/ethereum-optimism/optimism/pull/8657) on the new blob encoding method for 4844. 

Instead of ignoring 1 byte of each field element, we now combine 4 of those remaining bytes together and encode 3 bytes of data into it. 

**Tests**

Wrote tests for small and large data encoding and decoding and invalid blobs.

**Metadata**

- More detailed encoding scheme #[[Link to Proto's Explanation](https://github.com/ethereum-optimism/optimism/pull/8657/files)]